### PR TITLE
Improve perf by not requesting the babel-ast

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -39,7 +39,6 @@ const noopTimings = { timings: [], start: n => {}, end: n => {} };
  * @param {number} [$0.options.corejsVersion]
  */
 export async function process ({ file, source, map, options = {} }) {
-  const { minify, downlevel } = options;
   const { timings, start, end } = options.timings ? createPerformanceTimings() : noopTimings;
   const { minify, downlevel, modernize } = options;
 


### PR DESCRIPTION
 FROM:

```
    3432ms: Optimize Assets
    3430ms:  └ main.83fdc.js
           848ms: modern
           825ms: modern-minify
          1651ms: legacy
    2408ms: Bundle Polyfills
          1267ms: parse
           928ms: generate
```

TO:

```
    3398ms: Optimize Assets
    3396ms:  └ main.83fdc.js
           847ms: modern
           852ms: modern-minify
          1588ms: legacy
    2126ms: Bundle Polyfills
          1040ms: parse
           880ms: generate
```

This also adds some TODO's that could ensure us getting safer results in the legacy babel step. Seperatly minifying Legacy and Modern also allows us to do the "unsafe" minifications for legacy which are safe for modern.

Something that I've been thinking about is that we could add some minor plugins that check the `ast` for `platform-polyfills` for instance `fetch`, when they see a `self.fetch = ` or `window.fetch =` or an assertion `if (fetch)` then we can remove these safely in modern mode as well saving additional bytes.

I'll look later today if we can seperate the legacy (+ minify step) into a seperate worker.

At this moment the example we're using does a server-side build, maybe we could introduce some integrations with popular `html` bundler integrations like `webpack-html-plugin`. I got a little branch where I tested a few approaches, this however would force us to decide on what `module-nomodule` approach we consider safest. https://github.com/JoviDeCroock/webpack-module-nomodule-plugin#output-modes.