### PR TITLE
feat: Exclude assets option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ plugins: [
 | `modernize` | `boolean\|true` | Attempt to upgrade ES5 syntax to equivalent modern syntax. |
 | `verbose` | `boolean\|false` | Will log performance information and information about polyfills. |
 | `polyfillsFilename` | `string\|polyfills.legacy.js` | The name for the chunk containing polyfills for the legacy bundle. |
+| `exclude` | `RegExp[]\|[]` | Asset patterns that should be excluded |
 
 
 ## How does this work?

--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,13 @@ const DEFAULT_OPTIONS = {
   /**
    * @default "polyfills.legacy.js"
    */
-  polyfillsFilename: 'polyfills.legacy.js'
+  polyfillsFilename: 'polyfills.legacy.js',
+
+  /**
+   * RegExp patterns of assets to exclude
+   * @default []
+   */
+  exclude: []
 };
 
 export default class OptimizePlugin {
@@ -130,7 +136,15 @@ export default class OptimizePlugin {
 
     const processing = new WeakMap();
     const chunkAssets = Array.from(compilation.additionalChunkAssets || []);
-    const files = [...chunkFiles, ...chunkAssets];
+    const files = [...chunkFiles, ...chunkAssets]
+      .filter((asset) => {
+        for (const pattern of this.options.exclude) {
+          if (pattern.test(asset)) {
+            return false;
+          }
+        }
+        return true;
+      });
 
     start('Optimize Assets');
     let transformed;


### PR DESCRIPTION
Allows users to set patterns for assets that should be excluded, like the following example:

```js
new OptimizePlugin({ exclude: [/^sw\.js/, /my-module\.js/] });
```

Testing this plugin for `preact-cli` and we run into a couple issues around Workbox in particular:

1) Workbox's `InjectManifest` has a later asset processing stage than `OptimizePlugin`, resulting in the following when we want to generate a service worker:

```
errored out during transformation  Error: Farm is ended, no more calls can be done to it
    at JestWorker._callFunctionWithArgs (/home/ryun/Projects/foobar/node_modules/optimize-plugin/node_modules/jest-worker/build/index.js:140:13)
    at JestWorker.WorkerPool.worker.enqueue (/home/ryun/Projects/foobar/node_modules/optimize-plugin/dist/optimize-plugin.js:233:24)
    at /home/ryun/Projects/foobar/node_modules/optimize-plugin/dist/optimize-plugin.js:477:40
    at Array.map (<anonymous>)
    at OptimizePlugin.optimize (/home/ryun/Projects/foobar/node_modules/optimize-plugin/dist/optimize-plugin.js:454:45)
    at /home/ryun/Projects/foobar/node_modules/optimize-plugin/dist/optimize-plugin.js:806:23
    at fn (/home/ryun/Projects/foobar/node_modules/webpack/lib/Compilation.js:534:19)
    at _next4 (eval at create (/home/ryun/Projects/foobar/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:140:17)
    at eval (eval at create (/home/ryun/Projects/foobar/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:161:1)
    at /home/ryun/Projects/foobar/node_modules/webpack/lib/Compilation.js:519:10
```

2) We don't want/need to process the service workers anyways