### PR TITLE
refactor: Moves WorkerPool creation to `apply()`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,11 +82,6 @@ export default class OptimizePlugin {
       if (this.options[i] == null) this.options[i] = DEFAULT_OPTIONS[i];
     }
 
-    this.workerPool = new WorkerPool({
-      workerPath: require.resolve('./worker'),
-      concurrency: this.options.concurrency
-    });
-
     // const { concurrency } = options;
     // const workerPath = require.resolve('./worker');
     // if (concurrency === 0 || concurrency === false) {
@@ -456,6 +451,11 @@ export default class OptimizePlugin {
   }
 
   apply (compiler) {
+    this.workerPool = new WorkerPool({
+      workerPath: require.resolve('./worker'),
+      concurrency: this.options.concurrency
+    });
+
     compiler.hooks.compilation.tap(NAME, compilation => {
       this.updateChunkHash(compilation);
 


### PR DESCRIPTION
Issue came from testing out in `preact-cli`.

While CLI's setup is pretty niche, this issue can arise if `opimize-plugin` is initialized but then removed from the Webpack config (like if a user strips it out using their `preact.config.js`). This seems to lock up the Webpack build, never allowing it to complete. Moving pool creation to `apply()` when Webpack actually installs the plugin seems to correct the issue.