### PR TITLE
fix: Incorrect extension removal in polyfill name replacement

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -248,7 +248,7 @@ export default class OptimizePlugin {
   async generatePolyfillsChunk (polyfills, cwd, timings) {
     const ENTRY = '\0entry';
 
-    const entryContent = polyfills.reduce((str, p) => `${str}\nimport "${p.replace('.js$', '')}";`, '');
+    const entryContent = polyfills.reduce((str, p) => `${str}\nimport "${p.replace(/\.js$/, '')}";`, '');
 
     const COREJS = require.resolve('core-js/package.json').replace('package.json', '');
     const isCoreJsPath = /(?:^|\/)core-js\/(.+)$/;

--- a/src/index.js
+++ b/src/index.js
@@ -248,7 +248,7 @@ export default class OptimizePlugin {
   async generatePolyfillsChunk (polyfills, cwd, timings) {
     const ENTRY = '\0entry';
 
-    const entryContent = polyfills.reduce((str, p) => `${str}\nimport "${p.replace('.js', '')}";`, '');
+    const entryContent = polyfills.reduce((str, p) => `${str}\nimport "${p.replace('.js$', '')}";`, '');
 
     const COREJS = require.resolve('core-js/package.json').replace('package.json', '');
     const isCoreJsPath = /(?:^|\/)core-js\/(.+)$/;


### PR DESCRIPTION
Well this was a fun one to find...

Notably, it'll incorrectly convert `core-js/modules/es.json.to-string-tag.js` into `core-js/modules/eson.to-string-tag.js`. Funky name, to be fair.

```
console.warn
    'core-js/modules/eson.to-string-tag.js' is imported by entry, but could not be resolved – treating it as an external dependency

      at Graph.defaultOnWarn [as onwarn] (../../node_modules/optimize-plugin/node_modules/rollup/dist/shared/node-entry.js:13596:17)
      at Graph.warn (../../node_modules/optimize-plugin/node_modules/rollup/dist/shared/node-entry.js:13404:14)
      at ModuleLoader.handleResolveId (../../node_modules/optimize-plugin/node_modules/rollup/dist/shared/node-entry.js:12412:24)
      at ModuleLoader.<anonymous> (../../node_modules/optimize-plugin/node_modules/rollup/dist/shared/node-entry.js:12298:30)
      at fulfilled (../../node_modules/optimize-plugin/node_modules/rollup/dist/shared/node-entry.js:38:28)
```